### PR TITLE
add TravisCI badge to README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,18 @@
 # Config file for automatic testing at travis-ci.org
 
 language: python
-python:
-  - 3.6
-  - 3.5
-  - 3.4
-  - 2.7
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.4
+      env: TOXENV=py34
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.6
+      env: TOXENV=flake8
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U tox-travis

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/appsembler/python-avl.svg?branch=bdant%2Fpatch)](https://travis-ci.org/appsembler/python-avl)
+
 # Appsembler Virtual Labs API Bindings
 
 

--- a/tests/test_avl.py
+++ b/tests/test_avl.py
@@ -23,7 +23,7 @@ class ResponseMock(object):
 
     def json(self):
         patch_fixture_filepath = Path('.') / 'tests' / 'avl_patch_response_fixture.json'  # noqa: E501
-        with open(patch_fixture_filepath, 'r+') as f:
+        with patch_fixture_filepath.open('r+') as f:
             return json.loads(f.read())
 
 
@@ -69,6 +69,6 @@ def test_patch_lab(response):
     assert lab.response.status_code == 200
 
     patch_fixture_filepath = Path('.') / 'tests' / 'avl_patch_response_fixture.json'  # noqa: E501
-    with open(patch_fixture_filepath, 'r+') as f:
+    with patch_fixture_filepath.open('r+') as f:
         assert lab.response.json()['planned_expiration_time'] == \
             json.loads(f.read())['planned_expiration_time']

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,8 @@ commands = flake8 avl
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}
-		AVL_DOMAIN = https://yourAVLDashboard.domain.com
-		AVL_API_TOKEN = yourToken
+    AVL_DOMAIN = https://yourAVLDashboard.domain.com
+    AVL_API_TOKEN = yourToken
 deps =
     -r{toxinidir}/requirements_dev.txt
 ; If you want to make tox run the tests with the same versions, create a

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ commands = flake8 avl
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}
+		AVL_DOMAIN = https://yourAVLDashboard.domain.com
+		AVL_API_TOKEN = yourToken
 deps =
     -r{toxinidir}/requirements_dev.txt
 ; If you want to make tox run the tests with the same versions, create a


### PR DESCRIPTION
I enabled TravisCI for the repo since there was already config. Tests aren't passing (I assume the config is just boilerplate?). But we ought to start running them and get them fixed.