### PR TITLE
just run the test environments that currently pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@
 language: python
 matrix:
   include:
-    - python: 2.7
-      env: TOXENV=py27
-    - python: 3.4
-      env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 
 Python bindings for the Appsembler API.
 
+## Supported Python versions
+
+- Python 3.5, 3.6
 
 ## Install
 
@@ -25,6 +28,7 @@ run the helper script included in this repo:
 
 ```
 $ chmod 700 ./add2path.sh
+$ ./add2path.sh
 ```
 
 ## Option 2: Install with `pip`

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,10 @@
 [tox]
-envlist = py27, py34, py35, py36, flake8
+envlist = py35, py36, flake8
 
 [travis]
 python =
     3.6: py36
     3.5: py35
-    3.4: py34
-    2.7: py27
 
 [testenv:flake8]
 basepython = python


### PR DESCRIPTION
If we want python 2.7 or 3.4 tests in the future we can get them passing before re-enabling them.